### PR TITLE
Upgraded nuget package to 1.1.3

### DIFF
--- a/NonSource/NuGet/T4Include.nuspec
+++ b/NonSource/NuGet/T4Include.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata schemaVersion="2">
     <id>T4Include</id>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <title>T4Include</title>
     <authors>Mårten Rånge</authors>
     <owners>Mårten Rånge</owners>
@@ -15,6 +15,8 @@
     <frameworkAssemblies>
     </frameworkAssemblies>
     <releaseNotes>
+        * 1.1.3   - T4Include changes
+                        - Fixed url to Dapper in sample TT
         * 1.1.2   - T4Include changes
                         - Generalized exclusion list to all variants
                         - Added sensible defaults to exclusion list

--- a/NonSource/NuGet/content/Include_T4Include.tt.pp
+++ b/NonSource/NuGet/content/Include_T4Include.tt.pp
@@ -13,4 +13,4 @@
         };
 #>
 
-<#@ include file="$(SolutionDir)\packages\T4Include.1.1.2\T4\IncludeWebFile.ttinclude" #>
+<#@ include file="$(SolutionDir)\packages\T4Include.1.1.3\T4\IncludeWebFile.ttinclude" #>


### PR DESCRIPTION
Fixed url to dapper in sample TT, pre-built Nuget available here https://github.com/devlead/T4Include/releases/download/NUGET1.1.3/T4Include.1.1.3.nupkg
