### PR TITLE
Added PersistentHashMap + Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Output
 *.user
 *.suo
 *.nupkg
+packages/

--- a/Collections/PersistentHashMap.cs
+++ b/Collections/PersistentHashMap.cs
@@ -1,0 +1,995 @@
+﻿// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+
+// Inspired by Clojure's Persistent Hash Map (https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/PersistentHashMap.java)
+//  and Phil Bagwell's Ideal Hash Trie (http://lampwww.epfl.ch/papers/idealhashtrees.pdf)
+//  and http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+
+namespace Source.Collections
+{
+  using System;
+  using System.Collections;
+  using System.Collections.Generic;
+  using System.Diagnostics;
+  using System.Globalization;
+  using System.Runtime.CompilerServices;
+  using System.Text;
+
+  abstract partial class PersistentHashMap<K, V> : IEnumerable<KeyValuePair<K ,V>>
+    where K : IEquatable<K>
+  {
+    internal static readonly PersistentHashMap.EmptyNode<K, V> EmptyNode = new PersistentHashMap.EmptyNode<K, V> ();
+
+    public bool IsEmpty
+    {
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      get
+      {
+        return Empty ();
+      }
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    public bool Visit (Func<K, V, bool> r)
+    {
+      if (r != null)
+      {
+        return Receive (r);
+      }
+      else
+      {
+        return true;
+      }
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    public PersistentHashMap<K, V> Set (K k, V v)
+    {
+      var h = (uint)k.GetHashCode ();
+      return Set (h, 0, new PersistentHashMap.KeyValueNode<K, V> (h, k, v));
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    public bool TryFind (K k, out V v)
+    {
+      return TryFind ((uint)k.GetHashCode (), 0, k, out v);
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    public PersistentHashMap<K, V> Unset (K k)
+    {
+      return Unset ((uint)k.GetHashCode (), 0, k) ?? EmptyNode;
+    }
+
+    public abstract PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m);
+
+#if PHM_TEST_BUILD
+    public bool CheckInvariant ()
+    {
+      return CheckInvariant (0, 0, 0);
+    }
+#endif
+
+    public abstract IEnumerator<KeyValuePair<K, V>> GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      return GetEnumerator ();
+    }
+
+#if PHM_TEST_BUILD
+    public override string ToString ()
+    {
+      var sb = new StringBuilder (16);
+      Describe (sb, 0);
+      return sb.ToString ();
+    }
+#endif
+
+#if PHM_TEST_BUILD
+    internal abstract bool                      CheckInvariant  (uint h, int s, int d);
+    internal abstract void                      Describe        (StringBuilder sb, int indent);
+#endif
+    internal virtual  bool                      Empty           ()
+    {
+      return false;
+    }
+    internal abstract bool                      Receive         (Func<K, V, bool> r);
+    internal abstract PersistentHashMap<K, V>   Set             (uint h, int s, PersistentHashMap.KeyValueNode<K, V> n);
+    internal abstract bool                      TryFind         (uint h, int s, K k, out V v);
+    internal abstract PersistentHashMap<K, V>   Unset           (uint h, int s, K k);
+  }
+
+  static partial class PersistentHashMap
+  {
+    internal static PersistentHashMap<K, V> Empty<K, V> ()
+      where K : IEquatable<K>
+    {
+      return PersistentHashMap<K ,V>.EmptyNode;
+    }
+
+    internal const int TrieShift    = 4                       ;
+    internal const int TrieMaxShift = 32                      ;
+    internal const int TrieMaxLevel = TrieMaxShift / TrieShift;
+    internal const int TrieMaxNodes = 1 << TrieShift          ;
+    internal const int TrieMask     = TrieMaxNodes - 1        ;
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static uint LocalHash (uint h, int s)
+    {
+      return (h >> s) & TrieMask;
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static uint Bit (uint h, int s)
+    {
+      return 1U << (int) LocalHash (h, s);
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static int PopCount (uint v)
+    {
+      // TODO: As we only need popcount for 16bits can this be optimized?
+      // From: http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+      //  many cpus support popcount natively but that isn't available in IL
+      v -=  ((v >> 1) & 0x55555555);
+      v =   (v & 0x33333333) + ((v >> 2) & 0x33333333);
+      v =   ((v + (v >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+      return (int)v;
+    }
+
+    internal static string FormatWith (this string format, params object[] args)
+    {
+      return string.Format (CultureInfo.InvariantCulture, format, args);
+    }
+
+    internal static StringBuilder IndentedLine (this StringBuilder sb, int indent, string line)
+    {
+      sb.Append (' ', indent);
+      sb.AppendLine (line);
+      return sb;
+    }
+
+    internal static StringBuilder FormatIndentedLine (this StringBuilder sb, int indent, string format, params object[] args)
+    {
+      return sb.IndentedLine (indent, format.FormatWith (args));
+    }
+
+    internal static bool CheckHash (uint h, uint ah, int s)
+    {
+      return (h & ((1 << s) - 1)) == ah;
+    }
+
+    // Note: Array.Copy seems significantly faster than for loops
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static T[] CopyArray<T> (T[] vs)
+    {
+      var nvs = new T[vs.Length];
+      Array.Copy (vs, nvs, vs.Length);
+      return nvs;
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static T[] CopyArrayMakeHoleLast<T> (T[] vs, T hole)
+    {
+      var nvs = new T[vs.Length + 1];
+      Array.Copy (vs, nvs, vs.Length);
+      nvs[vs.Length] = hole;
+      return nvs;
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static T[] CopyArrayMakeHole<T> (int at, T[] vs, T hole)
+    {
+      Debug.Assert (at <= vs.Length);
+
+      var nvs = new T[vs.Length + 1];
+      Array.Copy (vs, nvs, at);
+      Array.Copy (vs, at, nvs, at + 1, vs.Length - at);
+      nvs[at] = hole;
+      return nvs;
+    }
+
+    [MethodImpl (MethodImplOptions.AggressiveInlining)]
+    internal static T[] CopyArrayRemoveHole<T> (int at, T[] vs)
+    {
+      Debug.Assert (at < vs.Length);
+      Debug.Assert (vs.Length > 1);
+
+      var nvs = new T[vs.Length - 1];
+      Array.Copy (vs, nvs, at);
+      Array.Copy (vs, at + 1, nvs, at, vs.Length - at - 1);
+      return nvs;
+    }
+
+    internal static PersistentHashMap<K, U>[] ArrayMapValues<K, V, U> (Func<K, V, U> m, PersistentHashMap<K, V>[] vs)
+      where K : IEquatable<K>
+    {
+      var result = new PersistentHashMap<K, U>[vs.Length];
+
+      for (var iter = 0; iter < vs.Length; ++iter)
+      {
+        result[iter] = vs[iter].MapValues (m);
+      }
+
+      return result;
+    }
+
+    internal static KeyValueNode<K, U>[] ArrayMapKeyValues<K, V, U> (Func<K, V, U> m, KeyValueNode<K, V>[] vs)
+      where K : IEquatable<K>
+    {
+      var result = new KeyValueNode<K, U>[vs.Length];
+
+      for (var iter = 0; iter < vs.Length; ++iter)
+      {
+        result[iter] = (KeyValueNode<K, U>)vs[iter].MapValues (m);
+      }
+
+      return result;
+    }
+
+    internal sealed partial class EmptyNode<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        yield break;
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        return d < TrieMaxLevel;
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        sb.IndentedLine (indent, "Empty");
+      }
+#endif
+      internal override bool Empty ()
+      {
+        return true;
+      }
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        return true;
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        return n;
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        v = default (V);
+        return false;
+      }
+
+      internal override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        return null;
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return PersistentHashMap<K, U>.EmptyNode;
+      }
+    }
+
+    internal sealed partial class KeyValueNode<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public readonly uint Hash  ;
+      public readonly K    Key   ;
+      public readonly V    Value ;
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public KeyValueNode (uint h, K k, V v)
+      {
+        Hash  = h;
+        Key   = k;
+        Value = v;
+      }
+
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        yield return new KeyValuePair<K, V> (Key, Value);
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        return
+          d < TrieMaxLevel
+          && CheckHash (Hash, h, s)
+          && (Hash == (uint)Key.GetHashCode ());
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        sb.FormatIndentedLine (indent, "KeyValue Hash:0x{0:X08}, Key:{1}, Value:{2}", Hash, Key, Value);
+      }
+#endif
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        return r (Key, Value);
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        // TODO: Optimize if h,k and v are identical?
+
+        // No need to check for reference equality as parent always creates new KeyValueNode
+        if (Hash == h && Key.Equals (n.Key))
+        {
+          // Replaces current node
+          return n;
+        }
+        else if (Hash == h)
+        {
+          return HashCollisionNodeN<K ,V>.FromTwoNodes (h, this, n);
+        }
+        else
+        {
+          return BitmapNodeN<K ,V>.FromTwoNodes (s, Hash, this, h, n);
+        }
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        if (Hash == h && Key.Equals (k))
+        {
+          v = Value;
+          return true;
+        }
+        else
+        {
+          v = default (V);
+          return false;
+        }
+      }
+
+      internal override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        if (Hash == h && Key.Equals (k))
+        {
+          return null;
+        }
+        else
+        {
+          return this;
+        }
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return new KeyValueNode<K, U> (Hash, Key, m (Key, Value));
+      }
+    }
+
+    internal sealed partial class BitmapNode1<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public readonly uint                      Bitmap  ;
+      public readonly PersistentHashMap<K, V>  Node    ;
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public BitmapNode1 (uint b, PersistentHashMap<K, V> n)
+      {
+        Bitmap  = b ;
+        Node    = n ;
+      }
+
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        foreach (var kv in Node)
+        {
+          yield return kv;
+        }
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        if (d >= TrieMaxLevel)
+        {
+          return false;
+        }
+
+        if (PopCount (Bitmap) != 1)
+        {
+          return false;
+        }
+
+        var bitmap = Bitmap;
+
+        var localIdx = PopCount (Bitmap - 1);
+
+        if (!Node.CheckInvariant (h | (uint)(localIdx << s), s + TrieShift, d + 1))
+        {
+          return false;
+        }
+
+        return true;
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        var bits = Convert.ToString (Bitmap, 2);
+        sb.FormatIndentedLine (indent, "Bitmap1 Bitmap:0b{0}", new string ('0', 16 - bits.Length) + bits);
+        Node.Describe (sb, indent + 2);
+      }
+#endif
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        if (!Node.Receive (r))
+        {
+          return false;
+        }
+
+        return true;
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        var bit = Bit (h, s);
+        if ((bit & Bitmap) != 0)
+        {
+          return new BitmapNode1<K, V> (Bitmap, Node.Set (h, s + TrieShift, n));
+        }
+        else if (Bitmap < bit)
+        {
+          return new BitmapNodeN<K,V> (Bitmap | bit, new PersistentHashMap<K, V> [] { Node, n });
+        }
+        else
+        {
+          return new BitmapNodeN<K,V> (bit | Bitmap, new PersistentHashMap<K, V> [] { n, Node });
+        }
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        var bit = Bit (h, s);
+        if ((bit & Bitmap) != 0)
+        {
+          return Node.TryFind (h, s + TrieShift, k, out v);
+        }
+        else
+        {
+          v = default (V);
+          return false;
+        }
+      }
+
+      internal sealed override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        var bit = Bit (h, s);
+        if ((bit & Bitmap) != 0)
+        {
+          var localIdx  = PopCount (Bitmap & (bit - 1));
+          var updated   = Node.Unset (h, s + TrieShift, k);
+          if (ReferenceEquals (updated, Node))
+          {
+            return this;
+          }
+          else if (updated != null)
+          {
+            return new BitmapNode1<K, V> (Bitmap, updated);
+          }
+          else
+          {
+            return null;
+          }
+        }
+        else
+        {
+          return this;
+        }
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return new BitmapNode1<K, U> (Bitmap, Node.MapValues (m));
+      }
+    }
+
+    internal sealed partial class BitmapNodeN<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public readonly uint              Bitmap  ;
+      public readonly PersistentHashMap<K, V>[]  Nodes   ;
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public BitmapNodeN (uint b, PersistentHashMap<K, V>[] ns)
+      {
+        Bitmap  = b ;
+        Nodes   = ns;
+      }
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public static PersistentHashMap<K, V> FromTwoNodes (int s, uint h1, PersistentHashMap<K, V> n1, uint h2, PersistentHashMap<K, V> n2)
+      {
+        Debug.Assert (h1 != h2);
+        Debug.Assert (s < TrieMaxShift);
+
+        var b1 = Bit (h1, s);
+        var b2 = Bit (h2, s);
+        if (b1 < b2)
+        {
+          return new BitmapNodeN<K, V> (b1 | b2, new [] { n1, n2 });
+        }
+        else if (b1 > b2)
+        {
+          return new BitmapNodeN<K, V> (b2 | b1, new [] { n2, n1 });
+        }
+        else
+        {
+          return new BitmapNode1<K, V> (b1, FromTwoNodes (s + TrieShift, h1, n1, h2, n2));
+        }
+      }
+
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        foreach (var node in Nodes)
+        {
+          foreach (var kv in node)
+          {
+            yield return kv;
+          }
+        }
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        if (d >= TrieMaxLevel)
+        {
+          return false;
+        }
+
+        var length = PopCount (Bitmap);
+        if (length < 2 || length != Nodes.Length)
+        {
+          return false;
+        }
+
+        var bitmap = Bitmap;
+
+        var hash = -1;
+        var iter = -1;
+
+        while (bitmap != 0)
+        {
+          ++hash;
+
+          var isSet = (bitmap & 0x1) != 0;
+          bitmap >>= 1;
+
+          if (!isSet)
+          {
+            continue;
+          }
+
+          ++iter;
+
+          var n = Nodes[iter];
+          if (n == null)
+          {
+            return false;
+          }
+
+          if (!n.CheckInvariant (h | (uint)(hash << s), s + TrieShift, d + 1))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        var bits = Convert.ToString (Bitmap, 2);
+        sb.FormatIndentedLine (indent, "BitmapN Bitmap:0b{0}, Nodes:{1}", new string ('0', 16 - bits.Length) + bits, Nodes.Length);
+        for (var iter = 0; iter < Nodes.Length; ++iter)
+        {
+          var n = Nodes[iter];
+          n.Describe (sb, indent + 2);
+        }
+      }
+#endif
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        for (var iter = 0; iter < Nodes.Length; ++iter)
+        {
+          if (!Nodes[iter].Receive (r))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        var bit = Bit (h, s);
+        var localIdx = PopCount (Bitmap & (bit - 1));
+        if ((bit & Bitmap) != 0)
+        {
+          var nvs = CopyArray (Nodes);
+          nvs[localIdx] = Nodes[localIdx].Set (h, s + TrieShift, n);
+          return new BitmapNodeN<K, V> (Bitmap, nvs);
+        }
+        else
+        {
+          var nvs = CopyArrayMakeHole (localIdx, Nodes, n);
+          if (nvs.Length < TrieMaxNodes)
+          {
+            return new BitmapNodeN<K, V> (Bitmap | bit, nvs);
+          }
+          else
+          {
+            return new BitmapNode16<K, V> (nvs);
+          }
+        }
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        var bit = Bit (h, s);
+        if ((bit & Bitmap) != 0)
+        {
+          var localIdx = PopCount (Bitmap & (bit - 1));
+          return Nodes[localIdx].TryFind (h, s + TrieShift, k, out v);
+        }
+        else
+        {
+          v = default (V);
+          return false;
+        }
+      }
+
+      internal sealed override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        var bit = Bit (h, s);
+        if ((bit & Bitmap) != 0)
+        {
+          var localIdx  = PopCount (Bitmap & (bit - 1));
+          var updated   = Nodes[localIdx].Unset (h, s + TrieShift, k);
+          if (ReferenceEquals (updated, Nodes[localIdx]))
+          {
+            return this;
+          }
+          else if (updated != null)
+          {
+            var nvs = CopyArray (Nodes);
+            nvs[localIdx] = updated;
+            return new BitmapNodeN<K, V> (Bitmap, nvs);
+          }
+          else if (Nodes.Length > 2)
+          {
+            return new BitmapNodeN<K, V> (Bitmap & ~bit, CopyArrayRemoveHole (localIdx, Nodes));
+          }
+          else if (Nodes.Length == 2)
+          {
+            return new BitmapNode1<K, V> (Bitmap & ~bit, Nodes[localIdx ^ 0x1]);
+          }
+          else
+          {
+            return null;
+          }
+        }
+        else
+        {
+          return this;
+        }
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return new BitmapNodeN<K, U> (Bitmap, ArrayMapValues (m, Nodes));
+      }
+    }
+
+    internal sealed partial class BitmapNode16<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public readonly PersistentHashMap<K, V>[]  Nodes   ;
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public BitmapNode16 (PersistentHashMap<K, V>[] ns)
+      {
+        Nodes   = ns ;
+      }
+
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        foreach (var node in Nodes)
+        {
+          foreach (var kv in node)
+          {
+            yield return kv;
+          }
+        }
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        if (d >= TrieMaxLevel)
+        {
+          return false;
+        }
+
+        if (TrieMaxNodes != Nodes.Length)
+        {
+          return false;
+        }
+
+        for (var iter = 0; iter < TrieMaxNodes; ++iter)
+        {
+          var n = Nodes[iter];
+          if (n == null)
+          {
+            return false;
+          }
+
+          if (!n.CheckInvariant (h | (uint)(iter << s), s + TrieShift, d + 1))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        sb.IndentedLine (indent, "Bitmap16");
+        foreach (var node in Nodes)
+        {
+          node.Describe (sb, indent + 2);
+        }
+      }
+#endif
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        foreach (var node in Nodes)
+        {
+          if (!node.Receive (r))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        var localIdx  = (int)LocalHash (h, s);
+        var nvs       = CopyArray (Nodes);
+        nvs[localIdx] = Nodes[localIdx].Set (h, s + TrieShift, n);
+        return new BitmapNode16<K, V> (nvs);
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        var localIdx  = (int)LocalHash (h, s);
+        return Nodes[localIdx].TryFind (h, s + TrieShift, k, out v);
+      }
+
+      internal sealed override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        var localIdx  = (int)LocalHash (h, s);
+        var updated   = Nodes[localIdx].Unset (h, s + TrieShift, k);
+        if (ReferenceEquals (updated, Nodes[localIdx]))
+        {
+          return this;
+        }
+        else if (updated != null)
+        {
+          var nv        = Nodes[localIdx] ;
+          var nvs       = CopyArray (Nodes);
+          nvs[localIdx] = updated;
+          return new BitmapNode16<K, V> (nvs);
+        }
+        else
+        {
+          var bit = Bit (h, s);
+          return new BitmapNodeN<K, V> (0xFFFF & ~bit, CopyArrayRemoveHole (localIdx, Nodes));
+        }
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return new BitmapNode16<K, U> (ArrayMapValues (m, Nodes));
+      }
+    }
+
+    internal sealed partial class HashCollisionNodeN<K, V> : PersistentHashMap<K, V>
+      where K : IEquatable<K>
+    {
+      public readonly uint                 Hash      ;
+      public readonly KeyValueNode<K, V>[] KeyValues ;
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public HashCollisionNodeN (uint h, KeyValueNode<K, V>[] kvs)
+      {
+        Hash      = h   ;
+        KeyValues = kvs ;
+      }
+
+      [MethodImpl (MethodImplOptions.AggressiveInlining)]
+      public static HashCollisionNodeN<K, V> FromTwoNodes (uint h, KeyValueNode<K, V> kv1, KeyValueNode<K, V> kv2)
+      {
+        return new HashCollisionNodeN<K, V> (h, new [] { kv1, kv2 });
+      }
+
+      public override IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+      {
+        foreach (var kv in KeyValues)
+        {
+          yield return new KeyValuePair<K, V> (kv.Key, kv.Value);
+        }
+      }
+
+#if PHM_TEST_BUILD
+      internal override bool CheckInvariant (uint h, int s, int d)
+      {
+        if (d >= TrieMaxLevel)
+        {
+          return false;
+        }
+
+        if (KeyValues.Length < 2)
+        {
+          return false;
+        }
+
+        for (var iter = 0; iter < KeyValues.Length; ++iter)
+        {
+          var kv = KeyValues[iter];
+          var k = kv.Key;
+          if ((uint)k.GetHashCode () != Hash)
+          {
+            return false;
+          }
+
+          if (!kv.CheckInvariant (h, s, d + 1))
+          {
+            return false;
+          }
+        }
+
+        return CheckHash (Hash, h, s);
+      }
+
+      internal override void Describe (StringBuilder sb, int indent)
+      {
+        sb.FormatIndentedLine (indent, "HashCollison Hash:0x{0:X08}, KeyValues:{1}", Hash, KeyValues.Length);
+        for (var iter = 0; iter < KeyValues.Length; ++iter)
+        {
+          var kv = KeyValues[iter];
+          kv.Describe (sb, indent + 2);
+        }
+      }
+#endif
+
+      internal override bool Receive (Func<K, V, bool> r)
+      {
+        for (var iter = 0; iter < KeyValues.Length; ++iter)
+        {
+          var kv = KeyValues[iter];
+          if (!r (kv.Key, kv.Value))
+          {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      internal sealed override PersistentHashMap<K, V> Set (uint h, int s, KeyValueNode<K, V> n)
+      {
+        if (Hash == h)
+        {
+          var k = n.Key;
+          for (var iter = 0; iter < KeyValues.Length; ++iter)
+          {
+            if (KeyValues[iter].Key.Equals (k))
+            {
+              var rvs = CopyArray (KeyValues);
+              rvs[iter] = n;
+              return new HashCollisionNodeN<K, V> (h, rvs);
+            }
+          }
+
+          return new HashCollisionNodeN<K, V> (h, CopyArrayMakeHoleLast (KeyValues, n));
+        }
+        else
+        {
+          return BitmapNodeN<K, V>.FromTwoNodes (s, Hash, this, h, n);
+        }
+      }
+
+      internal sealed override bool TryFind (uint h, int s, K k, out V v)
+      {
+        if (Hash == h)
+        {
+          for (var iter = 0; iter < KeyValues.Length; ++iter)
+          {
+            var kv = KeyValues[iter];
+            if (kv.Key.Equals (k))
+            {
+              v = kv.Value;
+              return true;
+            }
+          }
+
+          v = default (V);
+          return false;
+        }
+        else
+        {
+          v = default (V);
+          return false;
+        }
+      }
+
+      internal override PersistentHashMap<K, V> Unset (uint h, int s, K k)
+      {
+        if (Hash == h)
+        {
+          for (var iter = 0; iter < KeyValues.Length; ++iter)
+          {
+            if (KeyValues[iter].Key.Equals (k))
+            {
+              if (KeyValues.Length > 2)
+              {
+                return new HashCollisionNodeN<K, V> (h, CopyArrayRemoveHole (iter, KeyValues));
+              }
+              if (KeyValues.Length == 2)
+              {
+                return KeyValues[iter ^ 0x1];
+              }
+              else
+              {
+                return null;
+              }
+            }
+          }
+
+          return this;
+        }
+        else
+        {
+          return this;
+        }
+      }
+
+      public override PersistentHashMap<K, U> MapValues<U> (Func<K, V, U> m)
+      {
+        return new HashCollisionNodeN<K, U> (Hash, ArrayMapKeyValues (m, KeyValues));
+      }
+    }
+  }
+}

--- a/MakePublic.cs
+++ b/MakePublic.cs
@@ -10,12 +10,18 @@
 // You must not remove this notice, or any other, from this software.
 // ----------------------------------------------------------------------------------------------
 
-using System.Reflection;
-using System.Runtime.CompilerServices;
+namespace Source
+{
+  namespace Collections
+  {
+    // PersistentHashMap properties is tested by F# test suite which obviously can't include
+    //  C# code directly
+    public partial class PersistentHashMap<K, V>
+    {
+    }
 
-[assembly: AssemblyTitle("Source")]
-[assembly: AssemblyDescription("This library is not meant to be compiled and referenced. Instead it's meant to be included")]
-
-#if PHM_TEST_BUILD
-[assembly: InternalsVisibleTo("Test_Properties")]
-#endif
+    public partial class PersistentHashMap
+    {
+    }
+  }
+}

--- a/NonSource/Tests/Test_Properties/App.config
+++ b/NonSource/Tests/Test_Properties/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/NonSource/Tests/Test_Properties/AssemblyInfo.fs
+++ b/NonSource/Tests/Test_Properties/AssemblyInfo.fs
@@ -1,0 +1,34 @@
+﻿// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+
+namespace Test_Properties.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+[<assembly: AssemblyTitle("Test_Properties")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("T4Include")>]
+[<assembly: AssemblyCopyright("Copyright © Mårten Rånge 2016")>]
+[<assembly: AssemblyTrademark("T4Include")>]
+[<assembly: AssemblyCulture("")>]
+
+[<assembly: ComVisible(false)>]
+
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/NonSource/Tests/Test_Properties/PersistentHashMapProperties.fs
+++ b/NonSource/Tests/Test_Properties/PersistentHashMapProperties.fs
@@ -1,0 +1,343 @@
+﻿// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+
+module PersistentHashMapProperties
+
+open FsCheck
+open Source.Collections
+
+open System
+open System.Collections.Generic
+
+module FsCheckConfig =
+  open FsCheck
+#if DEBUG
+  let testCount = 100
+#else
+  let testCount = 1000
+#endif
+  let config = { Config.Quick with MaxTest = testCount; MaxFail = testCount }
+
+module FsLinq =
+  open System.Linq
+
+  let inline first    source                        = Enumerable.First    (source)
+  let inline groupBy  (selector : 'T -> 'U) source  = Enumerable.GroupBy  (source, Func<'T, 'U> selector)
+  let inline last     source                        = Enumerable.Last     (source)
+  let inline map      (selector : 'T -> 'U) source  = Enumerable.Select   (source, Func<'T, 'U> selector)
+  let inline sortBy   (selector : 'T -> 'U) source  = Enumerable.OrderBy  (source, Func<'T, 'U> selector)
+  let inline toArray  source                        = Enumerable.ToArray  (source)
+
+module Common =
+  let makeRandom (seed : int) =
+    let mutable state = int64 seed
+    let m = 0x7FFFFFFFL // 2^31 - 1
+    let d = 1. / float m
+    let a = 48271L      // MINSTD
+    let c = 0L
+    fun (b : int) (e : int) ->
+      state <- (a*state + c) % m
+      let r = float state * d
+      let v = float (e - b)*r + float b |> int
+      v
+
+  let shuffle random vs =
+    let a = Array.copy vs
+    for i in 0..(vs.Length - 2) do
+      let s =  random i vs.Length
+      let t =  a.[s]
+      a.[s] <- a.[i]
+      a.[i] <- t
+    a
+
+  let notIdentical<'T when 'T : not struct> (f : 'T) (s : 'T) = obj.ReferenceEquals (f, s) |> not
+
+  let popCount v =
+    let rec loop c v =
+      if v <> 0u then
+        loop (c + 1) (v &&& (v - 1u))
+      else
+        c
+    loop 0 v
+
+  let copyArrayMakeHole at (vs : 'T []) hole =
+    let nvs = Array.zeroCreate (vs.Length + 1)
+    let rec idLoop c i =
+      if i < vs.Length then
+        if c = 0 then
+          skipLoop i
+        else
+          nvs.[i] <- vs.[i]
+          idLoop (c - 1) (i + 1)
+    and skipLoop i =
+      if i < vs.Length then
+        nvs.[i + 1] <- vs.[i]
+        skipLoop (i + 1)
+    idLoop at 0
+    nvs.[at] <- hole
+    nvs
+
+  let empty () = PersistentHashMap.Empty<_, _> ()
+
+  let set k v (phm : PersistentHashMap<_, _>) = phm.Set (k, v)
+
+  let length (phm : PersistentHashMap<_, _>) =
+    let mutable l = 0
+    let visitor _ _ = l <- l + 1; true
+    phm.Visit (System.Func<_, _, _> visitor) |> ignore
+    l
+
+  let mapValues (m : 'K -> 'V -> 'U) (phm : PersistentHashMap<_, _>) =
+    phm.MapValues (System.Func<_, _, _> m)
+
+  let uniqueKey vs =
+    vs
+    |> FsLinq.groupBy fst
+    |> FsLinq.map (fun g -> g.Key, (g |> FsLinq.map snd |> FsLinq.last))
+    |> FsLinq.sortBy fst
+    |> FsLinq.toArray
+
+  let fromArray kvs =
+    Array.fold
+      (fun s (k, v) -> set k v s)
+      (empty ())
+      kvs
+
+  let toArray (phm : PersistentHashMap<'K, 'V>) =
+    phm
+    |> FsLinq.map (fun kv -> kv.Key, kv.Value)
+    |> FsLinq.toArray
+
+  let toSortedKeyArray phm =
+    let vs = phm |> toArray
+    vs |> Array.sortInPlaceBy fst
+    vs
+
+  let checkInvariant (phm : PersistentHashMap<'K, 'V>) = phm.CheckInvariant ()
+
+open Common
+
+[<AllowNullLiteral>]
+type Empty () =
+  inherit obj ()
+
+type ComplexType =
+  | IntKey    of  int
+  | StringKey of  int
+  | TupleKey  of  int*string
+
+type HalfHash(v : int) =
+  member x.Value = v
+
+  interface IComparable<HalfHash> with
+    member x.CompareTo(o : HalfHash)  = v.CompareTo o.Value
+
+  interface IEquatable<HalfHash> with
+    member x.Equals(o : HalfHash)  = v = o.Value
+
+  override x.Equals(o : obj)  =
+    match o with
+    | :? HalfHash as k -> v = k.Value
+    | _                -> false
+  override x.GetHashCode()    = (v.GetHashCode ()) >>> 16 // In order to get a fair bunch of duplicated hashes
+  override x.ToString()       = sprintf "%d" v
+
+type Action =
+  | Add     of int*string
+  | Remove  of int
+
+type Properties () =
+  static member ``PopCount returns number of set bits`` (i : uint32) =
+    let expected  = popCount i
+    let actual    = PersistentHashMap.PopCount i
+
+    expected      = actual
+
+  static member ``CopyArray copies the array`` (vs : int []) =
+    let expected  = vs
+    let actual    = PersistentHashMap.CopyArray vs
+
+    notIdentical expected actual
+    && expected = actual
+
+  static member ``CopyArrayMakeHoleLast copies the array and leaves a hole in last pos`` (vs : Empty []) (hole : Empty)=
+    let expected  = Array.append vs [| hole |]
+    let actual    = PersistentHashMap.CopyArrayMakeHoleLast (vs, hole)
+
+    notIdentical expected actual
+    && expected = actual
+
+  static member ``CopyArrayMakeHole copies the array and leaves a hole at pos`` (at : int) (vs : Empty []) (hole : Empty)=
+    let at        = abs at % (vs.Length + 1)
+    let expected  = copyArrayMakeHole at vs hole
+    let actual    = PersistentHashMap.CopyArrayMakeHole (at, vs, hole)
+
+    notIdentical expected actual
+    && expected = actual
+
+  static member ``PHM toArray must contain all added values`` (vs : (int*string) []) =
+    let expected  = uniqueKey vs
+    let phm       = vs |> fromArray
+    let actual    = phm |> toSortedKeyArray
+
+    notIdentical expected actual
+    && checkInvariant phm
+    && expected = actual
+
+  static member ``PHM TryFind must return all added values`` (vs : (ComplexType*ComplexType) []) =
+    let unique    = uniqueKey vs
+    let phm       = unique |> fromArray
+
+    let rec loop i =
+      if i < unique.Length then
+        let k, v = unique.[i]
+        match phm.TryFind k with
+        | true, fv when fv = v  -> loop (i + 1)
+        | _   , _               -> false
+      else
+        true
+
+    checkInvariant phm
+    && loop 0
+
+  static member ``PHM Unset on all added values must yield empty map`` (vs : (HalfHash*Empty) []) =
+    let unique    = uniqueKey vs
+    let phm       = unique |> fromArray
+
+    let rec loop (phm : PersistentHashMap<_, _>) i =
+      if checkInvariant phm |> not then
+        None
+      elif i < unique.Length then
+        if phm.IsEmpty then
+          None
+        else
+          let k, v = unique.[i]
+          loop (phm.Unset k) (i + 1)
+      else
+        Some phm
+
+    match loop phm 0 with
+    | Some phm  -> phm.IsEmpty
+    | None      -> false
+
+  static member ``PHM should behave as Map`` (vs : Action []) =
+    let compare map (phm : PersistentHashMap<_, _>) =
+      let empty =
+        match map |> Map.isEmpty, phm.IsEmpty with
+        | true  , true
+        | false , false -> true
+        | _     , _     -> false
+
+      let visitor k v =
+        match map |> Map.tryFind k with
+        | Some fv -> v = fv
+        | _       -> false
+
+      checkInvariant phm && (length phm = map.Count) && empty && phm.Visit (System.Func<_, _, _> visitor)
+
+    let ra = ResizeArray<int> ()
+
+    let rec loop map (phm : PersistentHashMap<_, _>) i =
+      if i < vs.Length then
+        match vs.[i] with
+        | Add (k, v)  ->
+          ra.Add k
+          let map = map |> Map.add k v
+          let phm = phm.Set (k, v)
+          compare map phm && loop map phm (i + 1)
+        | Remove r    ->
+          if ra.Count > 0 then
+            let r   = abs r % ra.Count
+            let k   = ra.[r]
+            ra.RemoveAt r
+            let map = map |> Map.remove k
+            let phm = phm.Unset k
+            compare map phm && loop map phm (i + 1)
+          else
+            loop map phm (i + 1)
+      else
+        true
+
+    loop Map.empty (empty ()) 0
+
+  static member ``PHM mapValues must contain all added and mapped values`` (vs : (int*int) []) =
+    let expected    = uniqueKey vs |> Array.map (fun (k, v) -> k, int64 k + int64 v + 1L)
+    let phm         = vs |> fromArray |> mapValues (fun k v -> int64 k + int64 v + 1L)
+    let actualArray = phm |> toSortedKeyArray
+
+    notIdentical expected  actualArray
+    && checkInvariant phm
+    && expected = actualArray
+
+let testLongInsert () =
+#if DEBUG
+  let count       = 1000
+#else
+  let count       = 1000000
+#endif
+  let multiplier  = 8
+  printfn "testLongInsert: count:%d, multiplier:%d" count multiplier
+  let random      = makeRandom 19740531
+  let inserts     = [| for x in 1..count -> random 0 (count * multiplier) |]
+  let lookups     = shuffle random inserts
+  let removals    = shuffle random inserts
+
+  let mutable phm = empty ()
+
+  for i in inserts do
+    phm <- phm.Set (i, i)
+    match phm.TryFind i with
+    | true, v when v = i  -> ()
+    | _                   -> failwith "testLongInsert/insert/tryFind failed"
+
+#if DEBUG
+    if phm |> checkInvariant |> not then
+      failwith "testLongInsert/insert/checkInvariant failed"
+#endif
+
+  if phm.IsEmpty then
+    failwith "testLongInsert/postInsert/checkEmpty failed"
+
+  if phm |> checkInvariant |> not then
+    failwith "testLongInsert/postInsert/checkInvariant failed"
+
+  for l in lookups do
+    match phm.TryFind l with
+    | true, v when v = l  -> ()
+    | _                   -> failwith "testLongInsert/lookup/tryFind failed"
+
+  if phm |> checkInvariant |> not then
+    failwith "testLongInsert/postLookup/checkInvariant failed"
+
+  for r in removals do
+    phm <- phm.Unset r
+    match phm.TryFind r with
+    | false , _ -> ()
+    | _         -> failwith "testLongInsert/remove/tryFind failed"
+
+#if DEBUG
+    if phm |> checkInvariant |> not then
+      failwith "testLongInsert/remove/checkInvariant failed"
+#endif
+
+  if phm |> checkInvariant |> not then
+    failwith "testLongInsert/postRemove/checkInvariant failed"
+
+  if phm.IsEmpty |> not then
+    failwith "testLongInsert/postRemove/checkEmpty failed"
+
+  printfn "  Done"
+
+let run () =
+  Check.All<Properties> FsCheckConfig.config
+  testLongInsert ()
+

--- a/NonSource/Tests/Test_Properties/Program.fs
+++ b/NonSource/Tests/Test_Properties/Program.fs
@@ -1,0 +1,16 @@
+﻿// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+
+[<EntryPoint>]
+let main argv =
+  PersistentHashMapProperties.run ()
+  0

--- a/NonSource/Tests/Test_Properties/Test_Properties.fsproj
+++ b/NonSource/Tests/Test_Properties/Test_Properties.fsproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>3310a1bd-f7d6-4aa0-b940-55fda2ebd369</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Test_Properties</RootNamespace>
+    <AssemblyName>Test_Properties</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>Test_Properties</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Test_Properties.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Test_Properties.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="PersistentHashMapProperties.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="FsCheck">
+      <HintPath>..\..\..\packages\FsCheck.2.6.2\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FSharp.Core">
+      <HintPath>..\..\..\packages\FSharp.Core.3.1.2.5\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\..\Source.csproj">
+      <Name>Source</Name>
+      <Project>{41c19388-e1bd-4387-8073-98d5761d6753}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NonSource/Tests/Test_Properties/packages.config
+++ b/NonSource/Tests/Test_Properties/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FsCheck" version="2.6.2" targetFramework="net452" />
+  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net452" />
+</packages>

--- a/Source.csproj
+++ b/Source.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>NonSource\Output\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PHM_TEST_BUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>NonSource\Output\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;PHM_TEST_BUILD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
@@ -55,6 +55,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Generated_SkipList.tt</DependentUpon>
     </Compile>
+    <Compile Include="Collections\PersistentHashMap.cs" />
     <Compile Include="Collections\SkipList.cs" />
     <Compile Include="Common\Array.cs" />
     <Compile Include="Common\BaseDisposable.cs" />
@@ -291,6 +292,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="NonSource\NuGet\content\T4IncludeControl.cs.pp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MakePublic.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/T4Include.sln
+++ b/T4Include.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Source", "Source.csproj", "{41C19388-E1BD-4387-8073-98D5761D6753}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_T4Include", "NonSource\Tests\Test_T4Include\Test_T4Include.csproj", "{1C271517-A4F0-4286-A0FF-1C8D52FDD641}"
@@ -12,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_FunctionalityNet20", "NonSource\Tests\Test_FunctionalityNet20\Test_FunctionalityNet20.csproj", "{14DC7BC3-5B08-4D56-B740-041338FD78E1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test_WPF", "NonSource\Tests\Test_WPF\Test_WPF.csproj", "{5B25A5E7-4FDF-4030-B740-8000B8D7B885}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Test_Properties", "NonSource\Tests\Test_Properties\Test_Properties.fsproj", "{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +43,10 @@ Global
 		{5B25A5E7-4FDF-4030-B740-8000B8D7B885}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5B25A5E7-4FDF-4030-B740-8000B8D7B885}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B25A5E7-4FDF-4030-B740-8000B8D7B885}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,5 +56,6 @@ Global
 		{8D7DB487-2771-4834-931E-C093E861B650} = {835F1A45-17C7-4D91-8F8E-45AADE338FA3}
 		{14DC7BC3-5B08-4D56-B740-041338FD78E1} = {835F1A45-17C7-4D91-8F8E-45AADE338FA3}
 		{5B25A5E7-4FDF-4030-B740-8000B8D7B885} = {835F1A45-17C7-4D91-8F8E-45AADE338FA3}
+		{3310A1BD-F7D6-4AA0-B940-55FDA2EBD369} = {835F1A45-17C7-4D91-8F8E-45AADE338FA3}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
A `PersistentHashMap`  is much like the `ImmutableDictionary` in `System.Collections.Immutable`.

This variant is based on a map in `FSharpX`, which in turn was based on a map in `clojure` which in turn was based on a paper by `Phil Bagwell` on `Idea Hash Trees`.

`PersistentHashMap` benefits from being includable as it can potentially reduce the footprint of an application.

In addition `PersistentHashMap` performance compares favorably to both `FSharpX` and `System.Collections.Immutable`.

```
# PersistentHashMap
Running test case: Local   - Lookup...
...It took 121 ms, CC=0, 0, 0
Running test case: Local   - Insert...
...It took 684 ms, CC=365, 0, 0
Running test case: Local   - Remove...
...It took 498 ms, CC=251, 0, 0
# FsharpX
Running test case: FSharpx - Lookup...
...It took 344 ms, CC=0, 0, 0
Running test case: FSharpx - Insert...
...It took 1436 ms, CC=685, 0, 0
Running test case: FSharpx - Remove...
...It took 1335 ms, CC=558, 0, 0
# System.Collections.Immutable
Running test case: SCI     - Lookup...
...It took 302 ms, CC=0, 0, 0
Running test case: SCI     - Insert...
...It took 4076 ms, CC=611, 0, 0
Running test case: SCI     - Remove...
...It took 2265 ms, CC=373, 0, 0
Press any key to continue . . .
```
